### PR TITLE
Fix "cd: command not found" error when executing tasks with sudo

### DIFF
--- a/lib/capistrano/grunt.rb
+++ b/lib/capistrano/grunt.rb
@@ -9,7 +9,7 @@ Capistrano::Configuration.instance(true).load do
     task :default, :roles => :app, :except => { :no_release => true } do
       tasks = Array(grunt_tasks)
       tasks.each do |task|
-        try_sudo "cd #{latest_release} && grunt #{grunt_options} #{task}"
+        run "cd #{latest_release} && #{try_sudo} grunt #{grunt_options} #{task}"
       end
     end
   end


### PR DESCRIPTION
When **use_sudo** is set to **true** in Capistrano config, executing any Grunt task produces the following error:

```
 * <[33mexecuting "sudo -p 'sudo password: ' cd /vagrant/releases/20130831114831 && grunt  default"<[0m
   servers: ["127.0.0.1"]
   [127.0.0.1:2222] executing command
** [out :: 127.0.0.1:2222] sudo: cd: command not found
```

Pull request fixes that.
