### PR TITLE
Make path to grunt configurable.

### DIFF
--- a/lib/capistrano/tasks/grunt.rake
+++ b/lib/capistrano/tasks/grunt.rake
@@ -21,7 +21,7 @@ task :grunt do
       options << "--gruntfile #{fetch(:grunt_file)}" if fetch(:grunt_file)
       options << fetch(:grunt_tasks) if fetch(:grunt_tasks)
 
-      execute :grunt, options
+      execute fetch(:grunt_bin), options
     end
   end
 end
@@ -36,5 +36,6 @@ namespace :load do
     set :grunt_tasks, nil
     set :grunt_flags, '--no-color'
     set :grunt_roles, :all
+    set :grunt_bin, :grunt
   end
 end


### PR DESCRIPTION
Provide an option to specify a path to the grunt-cli à la capistrano-bower.
