### PR TITLE
Revert "Make path to grunt configurable."

### DIFF
--- a/lib/capistrano/tasks/grunt.rake
+++ b/lib/capistrano/tasks/grunt.rake
@@ -21,7 +21,7 @@ task :grunt do
       options << "--gruntfile #{fetch(:grunt_file)}" if fetch(:grunt_file)
       options << fetch(:grunt_tasks) if fetch(:grunt_tasks)
 
-      execute fetch(:grunt_bin), options
+      execute :grunt, options
     end
   end
 end
@@ -36,6 +36,5 @@ namespace :load do
     set :grunt_tasks, nil
     set :grunt_flags, '--no-color'
     set :grunt_roles, :all
-    set :grunt_bin, :grunt
   end
 end


### PR DESCRIPTION
Reverts roots/capistrano-grunt#7

See reasoning here https://github.com/roots/capistrano-grunt/pull/6
